### PR TITLE
feat: add page "kampagner" and enhance LibrarySelect with dynamic props

### DIFF
--- a/app/kampagner/page.tsx
+++ b/app/kampagner/page.tsx
@@ -10,8 +10,8 @@ export default function KampagnerPage() {
           Du er der næsten
         </Typography>
         <p className="md:text-center">
-          Find dit bibliotek herunder for at blive omdirigeret til dit lokale
-          GO-site.
+          Find din kommune herunder for at blive omdirigeret til dit lokale
+          GO-site
         </p>
         <div className="mt-6 flex w-full flex-col justify-center space-y-4 md:mt-16">
           <Typography

--- a/app/kampagner/page.tsx
+++ b/app/kampagner/page.tsx
@@ -1,0 +1,30 @@
+import { LibrarySelect } from "@/components/library-select";
+import SupportDownloadCards from "@/components/SupportDownloadCards";
+import { Typography } from "@/components/typography";
+
+export default function KampagnerPage() {
+  return (
+    <div className="grid h-full w-full flex-1 grid-rows-[auto_min-content] items-center gap-8">
+      <div className="mx-auto grid w-full justify-center space-y-4 py-12">
+        <Typography variant={"h1"} as={"h1"} className="md:text-center">
+          Du er der næsten
+        </Typography>
+        <p className="md:text-center">
+          Find dit bibliotek herunder for at blive omdirigeret til dit lokale
+          GO-site.
+        </p>
+        <div className="mt-6 flex w-full flex-col justify-center space-y-4 md:mt-16">
+          <Typography
+            className="w-full md:text-center"
+            variant={"h4"}
+            as={"h2"}
+          >
+            Vælg kommune for at gå til dit lokale GO-site
+          </Typography>
+          <LibrarySelect className="mx-auto" customPath="/kampagner" />
+        </div>
+      </div>
+      <SupportDownloadCards />
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,4 @@
 import { LibrarySelect } from "@/components/library-select";
-import HtmlContent from "@/components/HtmlContent";
 import SupportDownloadCards from "@/components/SupportDownloadCards";
 import { Typography } from "@/components/typography";
 
@@ -10,12 +9,16 @@ export default function Home() {
         <Typography variant={"h1"} as={"h1"} className="md:text-center">
           eReolen GO er flyttet
         </Typography>
-        <HtmlContent src="/content/main.html" />
-        <div className="mx-auto mt-6 space-y-4 md:mt-16">
+        <div className="mx-auto mt-6 flex w-full flex-col justify-center space-y-4 md:mt-16">
           <Typography variant={"h4"} as={"h2"}>
             Vælg din kommune for at gå til dit lokale GO-site
           </Typography>
-          <LibrarySelect />
+          <LibrarySelect
+            className="mx-auto"
+            hoverHelpText="Hvis din skole er tilmeldt GO med UNI-login, skal du vælge
+                skolens kommune. Hvis du vil bruge almindeligt bibliotekslogin,
+                skal du vælge den kommune, du bor i."
+          />
         </div>
       </div>
       <SupportDownloadCards />

--- a/components/library-select.tsx
+++ b/components/library-select.tsx
@@ -23,18 +23,10 @@ import {
   HoverCardTrigger,
   HoverCardContent,
 } from "@/components/ui/hover-card";
-import { libraries } from "@/data/libraries";
+import { libraries, Library } from "@/data/libraries";
 import useLocalStorage from "@/hooks/useSelectedLibrary";
 import { buildRedirectUrl, cn } from "@/lib/utils";
 import { Typography } from "./typography";
-
-type Library = {
-  value: string;
-  label: string;
-  domain: string;
-  secondaryDomains: string[];
-  customPath?: string;
-};
 
 export function LibrarySelect({
   hoverHelpText,

--- a/components/library-select.tsx
+++ b/components/library-select.tsx
@@ -36,7 +36,15 @@ type Library = {
   customPath?: string;
 };
 
-export function LibrarySelect() {
+export function LibrarySelect({
+  hoverHelpText,
+  className,
+  customPath,
+}: {
+  hoverHelpText?: string;
+  className?: string;
+  customPath?: string;
+}) {
   const [open, setOpen] = useState(false);
   const [input, setInput] = useState("");
   const [storedValue, setStoredValue] = useLocalStorage<string>(
@@ -68,7 +76,7 @@ export function LibrarySelect() {
     const fullUrl = buildRedirectUrl({
       originalPath,
       libraryDomain: selectedLibrary.domain,
-      // customPath: selectedLibrary.customPath,
+      customPath: customPath || selectedLibrary.customPath,
     });
 
     return (window.location.href = fullUrl);
@@ -77,7 +85,12 @@ export function LibrarySelect() {
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverAnchor asChild>
-        <div className="max-w-select max-w-select grid w-full grid-cols-[1fr_min-content] gap-2">
+        <div
+          className={cn(
+            `max-w-select max-w-select grid w-full grid-cols-[1fr_min-content] gap-2`,
+            className,
+          )}
+        >
           <HoverCard>
             <HoverCardTrigger>
               <PopoverTrigger asChild>
@@ -95,13 +108,13 @@ export function LibrarySelect() {
                 </Button>
               </PopoverTrigger>
             </HoverCardTrigger>
-            <HoverCardContent className="w-80">
-              <Typography variant={"p"} as={"p"}>
-                Hvis din skole er tilmeldt GO med UNI-login, skal du vælge
-                skolens kommune. Hvis du vil bruge almindeligt bibliotekslogin,
-                skal du vælge den kommune, du bor i.
-              </Typography>
-            </HoverCardContent>
+            {hoverHelpText && (
+              <HoverCardContent className="w-80">
+                <Typography variant={"p"} as={"p"}>
+                  {hoverHelpText}
+                </Typography>
+              </HoverCardContent>
+            )}
           </HoverCard>
           <Button
             className="shadow-button focus-visible hover:shadow-button-hover border-foreground text-foreground pointer-events-auto inline-flex h-full w-[100px] items-center justify-center rounded-full border px-3 whitespace-nowrap uppercase transition hover:translate-x-[1px] hover:translate-y-[1px] hover:cursor-pointer active:translate-x-[4px] active:translate-y-[4px] active:shadow-none disabled:pointer-events-none disabled:opacity-50"

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -31,11 +31,11 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out ",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out",
           "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
           "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2",
-          " data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
-          className
+          "data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className,
         )}
         {...props}
       />

--- a/data/libraries.ts
+++ b/data/libraries.ts
@@ -1,4 +1,12 @@
-export const libraries = [
+export type Library = {
+  value: string;
+  label: string;
+  domain: string;
+  secondaryDomains: string[];
+  customPath?: string;
+};
+
+export const libraries: Library[] = [
   {
     value: "aabenraa",
     label: "Aabenraa",


### PR DESCRIPTION
### Link

https://reload.atlassian.net/browse/DDF-27

### Description

Branch Summary: DDF-27-go-mulighed-for-at-linke-til-konkret-stykke-indhold-via-landingpage

Overview
This branch adds a new /kampagner landing page and enhances the LibrarySelect component to support dynamic redirect paths.

### Key Changes

New /kampagner Page (app/kampagner/page.tsx)
•  Created a dedicated landing page for campaigns
•  Includes library selection with custom redirect to /kampagner on the selected library's domain

Enhanced LibrarySelect Component (components/library-select.tsx)
•  Added three new props:
◦  hoverHelpText: Optional help text in hover card
◦  className: Custom CSS classes for styling
◦  customPath: Redirect path for the selected library domain
•  Made hover help text conditional (only shows when provided)
•  Enabled customPath in buildRedirectUrl to override default redirect behavior